### PR TITLE
Add formula for FreeSWITCH compatible iLBC library

### DIFF
--- a/Formula/ilbc.rb
+++ b/Formula/ilbc.rb
@@ -1,0 +1,47 @@
+class Ilbc < Formula
+  desc "FreeSWITCH compatible internet low bit rate codec."
+  homepage "http://www.soft-switch.org/downloads/voipcodecs/"
+  url "http://www.soft-switch.org/downloads/voipcodecs/ilbc-0.0.1.tar.gz"
+  sha256 "52df3da6057dc05f1c9d699e0f3964dd256726effca9792f88b41148d3ca63a4"
+
+  def install
+    ENV.deparallelize
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+    (lib + "pkgconfig/ilbc.pc").write pc_file
+  end
+
+  def pc_file; <<-EOF
+prefix=#{prefix}
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include/libilbc
+
+Name: ilbc
+Description: Internet Low Bitrate Codec (iLBC) library for FreeSWITCH
+Version: 0.0.1
+Libs: -L${libdir} -lilbc
+Libs.private:
+Cflags: -I${includedir}/
+EOF
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <ilbc.h>
+      #include <stdio.h>
+
+      int main() {
+        ilbc_encode_state_t Enc_Inst;
+
+        ilbc_encode_init(&Enc_Inst, 20);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lilbc", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
The canonical formula for libilbc homebrew/Library/Formula/libilbc.rb,
based on the recent iLBC library release, is API incompatible with the
iLBC API used in FreeSWITCH. The in-tree version of libs/ilbc in the
FreeSWITCH source tree is based on a different API. This formula makes
that version available for install via homebrew. Additionally, it
creates a pkgconfig file so that the FreeSWITCH configure checks can
pick up this version.

From a quick perusal of the git logs, it appears that the source code
for the codec has been unmodified in the FreeSWITCH source tree, so
this Formula is based on the original tarball. The changes in the
FreeSWITCH source tree seem to be around getting the windows build to
work (these changes are of no concern to the homebrew build), and
silencing coverity warnings (since we're now packaging iLBC outside
the source tree, even these should not be essential).

---

If this is merged, please also update the list of dependencies mentioned on the [wiki](https://freeswitch.org/confluence/display/FREESWITCH/Installation+and+Testing+on+OS+X#InstallationandTestingonOSX-InstallPackageManagerandPrerequisites).
